### PR TITLE
Use py.test + coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ To do:
 
 Make sure your patch does not break any of the tests, and does not significantly reduce the readability of the code.
 
+Tests may be run using [py.test](http://pytest.org) (automatically finds tests/test_run.py)
+Test coverage may be obtained with the [coverage](https://pypi.python.org/pypi/coverage) module :
+
+```
+coverage run --source allantools setup.py test
+coverage report # Reports on standard output
+coverage html # Writes annotated source code as html in ./htmlcov/
+```
+
+
 References
 ==========
 http://en.wikipedia.org/wiki/Allan_variance

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import numpy
 
 setup(name='AllanTools',
-      version='1.1',
+      version='1.2.1',
       description='Allan deviation and related time/frequency statistics',
       author='Anders Wallin',
       author_email='anders.e.e.wallin@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,29 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
 import numpy
+import sys
+
+class PyTest(TestCommand):
+    """ Setup tests with py.test framework """
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 setup(name='AllanTools',
       version='1.2.1',
@@ -13,6 +35,8 @@ setup(name='AllanTools',
       packages=['allantools',],
       requires=['numpy'],
       include_dirs=[numpy.get_include()],
+      tests_require=['pytest'],
+      cmdclass={'test': PyTest},
       long_description="""Given phase or fractional frequency data this package calculates:
                         Allan deviation, overlapping Allan deviation, modified Allan deviation
                         Hadamard deviation, overlapping Hadamard deviation, time deviation,

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -6,7 +6,7 @@ import allantools as allan
 from allantools import noise
 import numpy
 
-def test( function, data, rate, taus):
+def _test( function, data, rate, taus):
 
 	(taus2,devs2,errs2,ns2) = function(data, rate, taus)
 	assert( len(taus2) == len(devs2) )
@@ -27,15 +27,15 @@ def run():
 	rate = 1.0
 	phase_white = noise.white(N)
 	taus_try = numpy.logspace(0,4,4000) # try insane tau values
-	test( allan.adev_phase, phase_white, rate, taus_try)
-	test( allan.oadev_phase, phase_white, rate, taus_try)
-	test( allan.mdev_phase, phase_white, rate, taus_try)
-	test( allan.tdev_phase, phase_white, rate, taus_try)
-	test( allan.hdev_phase, phase_white, rate, taus_try)
-	test( allan.ohdev_phase, phase_white, rate, taus_try)
-	test( allan.totdev_phase, phase_white, rate, taus_try)
-	test( allan.mtie_phase, phase_white, rate, taus_try)
-	test( allan.tierms_phase, phase_white, rate, taus_try)
+	_test( allan.adev_phase, phase_white, rate, taus_try)
+	_test( allan.oadev_phase, phase_white, rate, taus_try)
+	_test( allan.mdev_phase, phase_white, rate, taus_try)
+	_test( allan.tdev_phase, phase_white, rate, taus_try)
+	_test( allan.hdev_phase, phase_white, rate, taus_try)
+	_test( allan.ohdev_phase, phase_white, rate, taus_try)
+	_test( allan.totdev_phase, phase_white, rate, taus_try)
+	_test( allan.mtie_phase, phase_white, rate, taus_try)
+	_test( allan.tierms_phase, phase_white, rate, taus_try)
 
 if __name__ == "__main__":
 	run()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,48 @@
+"""
+  top-level test-script for allantools - for use with py.test framework
+  https://github.com/aewallin/allantools
+
+  this files runs all the tests defined in the /tests/ subdirectories
+  
+  More datasets along with known deviations (or calculated with 
+  known-good programs) are welcome.
+  
+  results from allantools seem correct, they agree to within 4 to 6 digits 
+  of precision with other ADEV tools.
+"""
+
+from nbs14 import nbs14_test
+from phasedat import phase_dat_test
+from pink_frequency import pink
+from Cs5071A import Cs5071A_test_decade
+from Keysight53230A_ti_noise_floor import TIC_test
+from ocxo import ocxo_test
+from test_ns import run as test_ns_run
+
+def test_ocxo():
+    # high-stability OCXO timebase on HP instrument
+    ocxo_test.run()
+
+def test_TIC(): 
+    # 53230A counter noise floor dataset
+    TIC_test.run()
+
+def test_nbs14():
+    # NBS14 test data with published deviations
+    nbs14_test.run()
+
+def test_phase_dat():
+    # phase.dat from Stable32
+    phase_dat_test.run() 
+
+def test_pink():
+    # synthetic pink frequency noise
+    pink.run() 
+
+def test_Cs5971A():
+    # HP 5071A Cs-clock measured against H-maser
+    Cs5071A_test_decade.run() 
+
+def test_ns():
+    # sanity-checks for tau values
+    test_ns_run() 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,6 +10,7 @@
   results from allantools seem correct, they agree to within 4 to 6 digits 
   of precision with other ADEV tools.
 """
+import pytest
 
 from nbs14 import nbs14_test
 from phasedat import phase_dat_test
@@ -46,3 +47,7 @@ def test_Cs5971A():
 def test_ns():
     # sanity-checks for tau values
     test_ns_run() 
+
+if __name__ == "__main__":
+    pytest.main()
+


### PR DESCRIPTION
After some trials (and errors...), here is a proposal for using py.test and coverage for developping allantools.

- switch to setup.py allows to use the "develop" command : e.g. "python3 setup.py develop --user" will do as "python3 setup.py install --user" except files are not copied, the egg contains a link to the development directory which allows to continue modifying the code and run it as if it is installed (avoids having to mess with the path within test suites, but for now I left those mostly untouched).

- running "py.test" from the top-level directory will find "tests/test_run.py" and run all the tests in it (the same ones as in runtest.py, without the output). Benefit : py.test takes care of summarizing the run. It may also allow to discriminate between "quick" and "lengthy" tests. I changed some names in test_ns.py to avoid some functions being run by py.test.

- Also, I modified setup.py so that "python3 setup.py test" runs py.test

- coverage can then be obtained with "coverage run --source allantools setup.py test" (or "python3 -m coverage run --source allantools setup.py test"), then "coverage report" or "coverage html".

As the changes are finally rather modest I assume they can share the same push request. But if you wish I can split it further.

I hope this helps...