### PR TITLE
Fix pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,8 @@ Tests may be run using py.test (http://pytest.org) (automatically finds
 tests/test_run.py) Test coverage may be obtained with the 
 [coverage](https://pypi.python.org/pypi/coverage) module::
 
-    coverage run --source allantools setup.py test coverage report # Reports on standard output 
+    coverage run --source allantools setup.py test 
+    coverage report # Reports on standard output 
     coverage html # Writes annotated source code as html in ./htmlcov/ ```
 
 On Ubuntu this requires packages **python-pytest** and **python-coverage**.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+# import numpy
 
 setup(name='AllanTools',
       version='2016.02',
@@ -9,14 +10,14 @@ setup(name='AllanTools',
       author_email='anders.e.e.wallin@gmail.com',
       url='https://github.com/aewallin/allantools',
       license='GPLv3+',
-      packages=['allantools'],
-      requires=['numpy', 'scipy'],
-      setup_requires=["pytest-runner"],
+      packages=['allantools',],
+      requires=['numpy'],
+      #include_dirs=[numpy.get_include()],
+      setup_requires=['pytest-runner'],
       tests_require=['pytest'],
-      long_description=(
-          "Given phase or fractional frequency data this package calculates: "
-          "Allan deviation, overlapping Allan deviation, modified Allan "
-          "deviation, Hadamard deviation, overlapping Hadamard deviation, "
-          "time deviation, itotal deviation, MTIE, TIE-RMS. Synthetic noise "
-          "data generators are also included.")
-      )
+      long_description="""Given phase or fractional frequency data this package calculates:
+                        Allan deviation, overlapping Allan deviation, modified Allan deviation,
+                        Hadamard deviation, overlapping Hadamard deviation, time deviation,
+                        total deviation, MTIE, TIE-RMS. Synthetic noise data generators are also included."""
+     )
+

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,6 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-# import numpy
-import sys
-
-class PyTest(TestCommand):
-    """ Setup tests with py.test framework """
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
 
 setup(name='AllanTools',
       version='2016.02',
@@ -32,14 +9,14 @@ setup(name='AllanTools',
       author_email='anders.e.e.wallin@gmail.com',
       url='https://github.com/aewallin/allantools',
       license='GPLv3+',
-      packages=['allantools',],
-      requires=['numpy'],
-      #include_dirs=[numpy.get_include()],
+      packages=['allantools'],
+      requires=['numpy', 'scipy'],
+      setup_requires=["pytest-runner"],
       tests_require=['pytest'],
-      cmdclass={'test': PyTest},
-      long_description="""Given phase or fractional frequency data this package calculates:
-                        Allan deviation, overlapping Allan deviation, modified Allan deviation,
-                        Hadamard deviation, overlapping Hadamard deviation, time deviation,
-                        total deviation, MTIE, TIE-RMS. Synthetic noise data generators are also included."""
-     )
-
+      long_description=(
+          "Given phase or fractional frequency data this package calculates: "
+          "Allan deviation, overlapping Allan deviation, modified Allan "
+          "deviation, Hadamard deviation, overlapping Hadamard deviation, "
+          "time deviation, itotal deviation, MTIE, TIE-RMS. Synthetic noise "
+          "data generators are also included.")
+      )


### PR DESCRIPTION
Hi,

setuptools 18.4 introduces some changes that made `python3 setup.py test` fail (which, in turn, made the coverage generation fail too).

Here I propose a fix for this, following http://pytest.org/latest/goodpractices.html#goodpractices

Additionally, I note that version tag "2016.02" raises a warning : 
`/usr/lib/python3/dist-packages/setuptools/dist.py:285: UserWarning: Normalizing '2016.02' to '2016.2'
  normalized_version,`

 PEP0440 (https://www.python.org/dev/peps/pep-0440/#version-epochs) prefers 2016.2, but of course this is up to you...

Lastly I fixed a missing newline in README.rst, which was scrambling the "coverage" commands.

Best regards,

-- 
 Frédéric