### PR TITLE
python3 compatibility

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -851,7 +851,7 @@ def theo1(phase=None, frequency=None, rate=1.0, taus=[]):
         n=0
         for i in range( int(N-m) ):
             s=0
-            for d in range( int(m)/2 ): # inner sum
+            for d in range( int(m/2) ): # inner sum
                 pre = 1.0 / (float(m)/2 - float(d))
                 s += pre*pow( phase[i]-phase[i-d+m/2] + phase[i+m]-phase[i+d+m/2] , 2)
                 n=n+1


### PR DESCRIPTION
Here python3 failed with
>               for d in range( int(m)/2 ): # inner sum
E               TypeError: 'float' object cannot be interpreted as an integer

There is indeed a test before : assert( m % 2 == 0 ), so we know that int(m)/2 is an integer, but obviously python3 static analyzer does not !

I moved a parenthesis, now the tests run (thanks for shortening their duration !)

As for python3, I don't know if it will be "by default" on ubuntu 16.04, but I have currently installed both of them on ubuntu 15.10 without major problems. In fact all my developments are now in python3, while parts of the system still rely on python2. I think it becomes more and more relevant to switch to python3 as a primary development target... But in the meantime I am happy to contribute and maintain python3 compatibility !