### PR TITLE
Merge 4 5params

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -1210,7 +1210,7 @@ def remove_small_ns(taus, devs, deverrs, ns):
         List of tau values for which deviation were computed
     devs: array
         List of deviations
-    deverrs: array or array of arrays
+    deverrs: array or list of arrays
         List of estimated errors (possibly a list containing two arrays :
         upper and lower values)
     ns: array

--- a/tests/functional_tests/test_remove_small_ns.py
+++ b/tests/functional_tests/test_remove_small_ns.py
@@ -1,0 +1,35 @@
+import pytest
+import allantools.allantools as at
+import numpy as np
+
+minimum_ns = 1
+
+taus = np.arange(1, 499)
+devs = np.random.rand(len(taus))
+deverrs_l = np.random.rand(len(taus))
+deverrs_h = np.random.rand(len(taus))
+ns = np.zeros(len(taus))
+ns[0] = len(ns)
+last_i = 0
+for i in range(1, len(ns)):
+    ns[i] = max(ns[i-1] // 2, 1.0)
+    if ns[i] > minimum_ns:
+        last_i = i + 1
+
+
+def test_4params():
+    (o_taus, o_devs, o_deverrs, o_ns) = at.remove_small_ns(
+        taus, devs, deverrs_l, ns)
+    np.testing.assert_array_equal(o_taus, taus[:last_i])
+    np.testing.assert_array_equal(o_devs, devs[:last_i])
+    np.testing.assert_array_equal(o_deverrs, deverrs_l[:last_i])
+    np.testing.assert_array_equal(o_ns, ns[:last_i])
+
+def test_5params():
+    (o_taus, o_devs, o_deverrs_l, o_deverrs_h, o_ns) = at.remove_small_ns(
+        taus, devs, deverrs_l, deverrs_h, ns)
+    np.testing.assert_array_equal(o_taus, taus[:last_i])
+    np.testing.assert_array_equal(o_devs, devs[:last_i])
+    np.testing.assert_array_equal(o_deverrs_l, deverrs_l[:last_i])
+    np.testing.assert_array_equal(o_deverrs_h, deverrs_h[:last_i])
+    np.testing.assert_array_equal(o_ns, ns[:last_i])

--- a/tests/functional_tests/test_remove_small_ns.py
+++ b/tests/functional_tests/test_remove_small_ns.py
@@ -26,8 +26,8 @@ def test_4params():
     np.testing.assert_array_equal(o_ns, ns[:last_i])
 
 def test_5params():
-    (o_taus, o_devs, o_deverrs_l, o_deverrs_h, o_ns) = at.remove_small_ns(
-        taus, devs, deverrs_l, deverrs_h, ns)
+    (o_taus, o_devs, [o_deverrs_l, o_deverrs_h], o_ns) = at.remove_small_ns(
+        taus, devs, [deverrs_l, deverrs_h], ns)
     np.testing.assert_array_equal(o_taus, taus[:last_i])
     np.testing.assert_array_equal(o_devs, devs[:last_i])
     np.testing.assert_array_equal(o_deverrs_l, deverrs_l[:last_i])


### PR DESCRIPTION
Hi,

This is a proposal for merging both 4-parameter and 5-parameter version of the "remove_small_ns" function, as suggested in the source.

In this, the number of parameters is fixed to 4, but the third can optionally be a list of arrays instead of a single array, limited to 2 elements. Output changes accordingly.

I also made a quick, basic unit test for it (first commit contains a version for the present situation : if you don't like the new code, you still can take the first version of the unit test if you wish).