### PR TITLE
Modified functions signature (API break !)

### DIFF
--- a/tests/nbs14/test_nbs14_1000point.py
+++ b/tests/nbs14/test_nbs14_1000point.py
@@ -99,7 +99,16 @@ class TestNBS14_1000Point():
     def nbs14_tester( self, function, pdata, fdata, correct_devs, taus =[1, 10, 100], soft=False ):
         rate=1.0
         
-        (taus2, devs, deverrs, ns) = function( phase=pdata, frequency=fdata, rate=rate, taus=taus)
+        if pdata != None and fdata == None:
+            (taus2, devs, deverrs, ns) = function(pdata,
+                                                  rate=rate, taus=taus)
+        elif pdata == None and fdata != None:
+            (taus2, devs, deverrs, ns) = function(fdata,
+                                                  data_type="freq",
+                                                  rate=rate, taus=taus)
+        else:
+            raise Exception("Ambiguous input data")
+
         for i in range(3):
             if soft:
                 print(' calculated ', devs[i] )

--- a/tests/nbs14/test_nbs14_10point.py
+++ b/tests/nbs14/test_nbs14_10point.py
@@ -95,8 +95,9 @@ class TestNBS14_10Point():
     def generic_test(self, function, ref_devs):
         taus = [1, 2]
         tol = 1e-4
-        (taus1,adevs1,aerrs1,ns1) = function( phase= nbs14_phase, rate=1.0, taus=taus)
-        (taus2,adevs2,aerrs2,ns2) = function( frequency=nbs14_f, rate=1.0, taus=taus)
+        (taus1,adevs1,aerrs1,ns1) = function(nbs14_phase, rate=1.0, taus=taus)
+        (taus2,adevs2,aerrs2,ns2) = function(nbs14_f, rate=1.0,
+                                             data_type="freq",taus=taus)
         assert( check_devs( adevs1[0], ref_devs[0] ) ) # tau=1 from phase data
         assert( check_devs( adevs1[1], ref_devs[1] ) ) # tau=2 from phase data
         assert( check_devs( adevs2[0], ref_devs[0] ) ) # tau=1 from frequency data

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -9,7 +9,7 @@ import numpy
 
 def _test( function, data, rate, taus):
 
-    (taus2,devs2,errs2,ns2) = function(phase=data, rate=rate, taus=taus)
+    (taus2,devs2,errs2,ns2) = function(data, rate=rate, taus=taus)
     assert( len(taus2) == len(devs2) )
     assert( len(taus2) == len(errs2) )
     assert( len(taus2) == len(ns2) )

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -76,15 +76,17 @@ def read_stable32(resultfile, datarate):
 def test(function, datafile, datarate, resultfile, frequency=False, verbose=0, tolerance=1e-4):
     # if Stable32 results were given with more digits we could decrease tolerance
 
-    phase = read_datafile(datafile)
-    print("Read ", len(phase), " phase values from ", datafile)
+    data = read_datafile(datafile)
+    print("Read ", len(data), " phase values from ", datafile)
     (taus, devs, ns) = read_stable32(resultfile, datarate)
 
     # run allantools algorithm
     if frequency:
-        (taus2, devs2, errs2, ns2) = function(frequency=phase, rate=datarate, taus=taus)
+        (taus2, devs2, errs2, ns2) = function(data, rate=datarate,
+                                              data_type="freq",
+                                              taus=taus)
     else:
-        (taus2, devs2, errs2, ns2) = function(phase=phase, rate=datarate, taus=taus)
+        (taus2, devs2, errs2, ns2) = function(data, rate=datarate, taus=taus)
 
     # check that allantools and Stable32 agree on length of DEV, Tau, and N results
 
@@ -111,12 +113,12 @@ def to_fractional(data):
 def test_row_by_row(function, datafile, datarate, resultfile, verbose=0, tolerance=1e-4, frequency=False, normalize=False):
     # if Stable32 results were given with more digits we could decrease tolerance
 
-    phase = read_datafile(datafile)
+    data = read_datafile(datafile)
 
     if normalize: # convert frequencies in Hz to fractional frequencies
-        phase = to_fractional(phase)
+        data = to_fractional(data)
 
-    print("Read ", len(phase), " values from ", datafile)
+    print("Read ", len(data), " values from ", datafile)
 
     (taus, devs, ns) = read_stable32(resultfile, datarate)
     print("test of function ", function )
@@ -125,9 +127,12 @@ def test_row_by_row(function, datafile, datarate, resultfile, verbose=0, toleran
     # run allantools algorithm, row by row
     for (tau, dev, n) in zip(taus, devs, ns):
         if frequency:
-            (taus2, devs2, errs2, ns2) = function(frequency=phase, rate=datarate, taus=[tau])
+            (taus2, devs2, errs2, ns2) = function(data, rate=datarate,
+                                                  data_type="freq",
+                                                  taus=[tau])
         else:
-            (taus2, devs2, errs2, ns2) = function(phase=phase, rate=datarate, taus=[tau])
+            (taus2, devs2, errs2, ns2) = function(data, rate=datarate,
+                                                  taus=[tau])
         check_deviations((tau, dev, n, taus2[0], devs2[0], ns2[0]), tolerance, verbose)
 
 


### PR DESCRIPTION
Following https://github.com/aewallin/allantools/issues/29, it has been
decided to change the signature of most functions.

This commit implements the necessary changes, with caveats :

- "type" parameter has been named "data_type" instead, in order to avoid
  collision with python's reserved word "type".
- "frequency" has been abbreviated to "freq", in order to lighten the
  function call (I think there are no ambiguities)
- "rate" parameter has been shifted to second position, in an effort to make
  it more visible.
- note that, as proposed, default values for "taus" is now None (vs.
  []). This avoids possible adverse effects (every succesive call to the
  same function with "taus" as default "[]" would be linked to the same
  object : this is very unlikely as it is currently useless to do so,
  but setting default to "None" rules this out completely and easily).

Test calls and docstrings have been modified accordingly.