### PR TITLE
Automate testing with tox and TravisCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ docs/_build/**
 MANIFEST
 build/**
 dist/**
+.eggs/
+.tox/
+*.egg-info/
+*.egg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+sudo: required
+install:
+    - sudo apt-get install liblapack-dev libblas-dev gfortran
+    - pip install -v .
+    - pip install -r requirements.txt
+script:
+    py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py33,py34,py35
+
+[testenv]
+deps =
+     pytest
+commands = py.test


### PR DESCRIPTION
This allows for automated testing using both tox and TravisCI as per #41. The latter can be seen [here](https://travis-ci.org/mivade/allantools). All tests pass on Pythons 2.7, 3.3-3.5.