### PR TITLE
Readme headings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,10 @@ AllanTools documentation
 .. toctree::
     :maxdepth: 2
    
-    ../README
+    readme_copy
     getting_started
     api
     dev
     references
 ..
    
-.. include:: ../README.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,16 +3,17 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-allantools documentation
+AllanTools documentation
 ========================
 
 .. toctree::
-   :maxdepth: 2
-
-   getting_started
-   api
-   dev
-   references
+    :maxdepth: 2
+   
+    ../README
+    getting_started
+    api
+    dev
+    references
 ..
    
 .. include:: ../README.rst

--- a/docs/readme_copy.rst
+++ b/docs/readme_copy.rst
@@ -1,0 +1,2 @@
+.. include:: ../README.rst
+


### PR DESCRIPTION
Hi,

Here is an attempt to solve issue #39.

Is this what you were thinking of ? To realize it I moved the "include" directive in a new file (readme_copy.rst), so toctree takes its heading too. But the text itself then disappears from the main page (I suppose we could just put the "include" directive _also_ in index.rst to have both headings and text, if you prefer).