### PR TITLE
Enforce README.rst encoding in setup.py open() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(name=pkginfo['name'],
       # include_dirs=[numpy.get_include()],
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'numpy'],
-      long_description=open('README.rst', 'r').read(),
+      long_description=open('README.rst', 'r', encoding='utf8').read(),
       )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from io import open
 import json
 import os
 


### PR DESCRIPTION
This is needed in case no locale is set and python3 defaults to ascii encoding for the file it opens. Case witnessed in a MacOS Terminal, leading to installation failure.
Thanks to M. Armano for pointing this out and help finding the root cause.