### PR TITLE
Fix a precision issue which occurs with frequency data if we deal wit…

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -1613,6 +1613,10 @@ def frequency2phase(freqdata, rate):
     # Protect against NaN values in input array (issue #60)
     # Reintroduces data trimming as in commit 503cb82
     freqdata = trim_data(freqdata)
+    # Erik Benkler (PTB): Subtract mean value before cumsum in order to 
+    # avoid precision issues when we have small frequency fluctuations on 
+    # a large average frequency
+    freqdata = freqdata - np.nanmean(freqdata)
     phasedata = np.cumsum(freqdata) * dt
     phasedata = np.insert(phasedata, 0, 0) # FIXME: why do we do this?
     # so that phase starts at zero and len(phase)=len(freq)+1 ??


### PR DESCRIPTION
…h small frequency fluctuations on a large mean frequency. Because frequency data is always converted to phase data using frequency2phase helper function first, the digits containing the info on the small frequency fluctuations get insignificant when using cumsum, because the sum can become much larger than these small fluctuations. As a remedy, subtract frequency average before conversion to phase data using cumsum.