### PR TITLE
Changed output format to mimic stable32's

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -28,6 +28,11 @@ def test_compute_functions(dataset):
         # Also test output for all types
         tmpfile = tempfile.NamedTemporaryFile(mode="w")
         dataset.write_results(tmpfile.name)
+        dataset.write_results(tmpfile.name,
+                              digits=10,
+                              header_params={"test":1, "test2":"foo"}
+                             )
+
 
 
 def test_dataset_parameters():


### PR DESCRIPTION
Followup on #97 

Not sure if you wish to include that in a rc2 or prefer to wait, this is up to you !

- alpha evaluation not implemented yet, so "NaN" in this column for the moment.
- uncertainty split in 2 to give min and max values
- all stats share same output format (contrary to what stable32 does,
eg. tierms vs adev).
- introduced "digits" parameter to tune the number of significant digits, as suggested.
- introduced "header_params" parameter to allow an arbitrary dict to be written in headers, as suggested.
- "# " is added at the start of header lines. This is different from stable32 but I think it is wishable.