### PR TITLE
Fix typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ frequency, is left to the user.
     a.compute("mdev")
 
     # New in 2019.7 : write results to file
-    a.write_result("output.dat")
+    a.write_results("output.dat")
 
     # Plot it using the Plot class
     b = allantools.Plot()


### PR DESCRIPTION
Hi guys,

Found a typo in the examples in `README.srt`

I'm a bit slow so it took me a while to realise that it wasn't because I had an outdated version ;)

Cheers,

Pete