### PR TITLE
Updated CI python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@
 matrix:
     include:
         - os: linux
-          name: "Linux/xenial - Python 2.7"
+          name: "Linux/xenial - Python 3.5 (oldest supported version)"
           dist: xenial   # required for Python >= 3.7
           language: python
           sudo: required
-          python:        # removed 3.3 because scipy gives and error
-              - 2.7
+          python:
+              - 3.5
           install:
               - sudo apt-get install liblapack-dev libblas-dev gfortran
               - pip install -v .      # allantools itself, verbose output
@@ -19,12 +19,12 @@ matrix:
           script:
               - py.test
         - os: linux
-          name: "Linux/xenial - Python 3.4, with coverage"
+          name: "Linux/xenial - Python 3.8, (latest supported version) with coverage"
           dist: xenial   # required for Python >= 3.7
           language: python
           sudo: required
-          python:        # removed 3.3 because scipy gives and error
-              - 3.4
+          python:
+              - 3.8
           install:
               - sudo apt-get install liblapack-dev libblas-dev gfortran
               - pip install -v .      # allantools itself, verbose output

--- a/tests/functional_tests/test_mask.py
+++ b/tests/functional_tests/test_mask.py
@@ -1,0 +1,65 @@
+from allantools import mask
+import numpy as np
+import pytest  # noqa
+
+import sys
+sys.path.append("..")
+
+# Test values have been calculated from the reference documents
+# indicated in the source
+
+
+def test_prc_tdev():
+    assert np.isclose(mask.prc_tdev(50),  3e-9)
+    assert np.isclose(mask.prc_tdev(500),  15e-9)
+    assert np.isclose(mask.prc_tdev(5000),  30e-9)
+
+
+def test_prc_mtie():
+    assert np.isclose(mask.prc_mtie(50),  0.03875e-6)
+    assert np.isclose(mask.prc_mtie(5000),  0.34e-6)
+
+
+def test_eprtc_tdev():
+    assert np.isclose(mask.eprtc_tdev(5), 1e-9)
+    assert np.isclose(mask.eprtc_tdev(50), .001666665e-9)
+
+
+def test_eprtc_mtie():
+    assert np.isclose(mask.eprtc_mtie(.5), 4e-9)
+    assert np.isclose(mask.eprtc_mtie(5), 4.4457e-9)
+    assert np.isclose(mask.eprtc_mtie(250), 15.009375e-9)
+    assert np.isclose(mask.eprtc_mtie(500000), 30e-9)
+
+
+def test_prtcA_tdev():
+    assert np.isclose(mask.prtcA_tdev(5), 3e-9)
+    assert np.isclose(mask.prtcA_tdev(500), 15e-9)
+    assert np.isclose(mask.prtcA_tdev(5000), 30e-9)
+
+
+def test_prtcB_tdev():
+    assert np.isclose(mask.prtcB_tdev(5), 1e-9)
+    assert np.isclose(mask.prtcB_tdev(250), 2.5e-9)
+    assert np.isclose(mask.prtcB_tdev(5000), 5e-9)
+
+
+def test_prtcA_mtie():
+    assert np.isclose(mask.prtcA_mtie(5), 0.026375e-6)
+    assert np.isclose(mask.prtcA_mtie(500), .1e-6)
+
+
+def test_prtcB_mtie():
+    assert np.isclose(mask.prtcB_mtie(5), 0.026375e-6)
+    assert np.isclose(mask.prtcB_mtie(500), .04e-6)
+
+
+if __name__ == "__main__":
+    test_prc_tdev()
+    test_prc_mtie()
+    test_eprtc_tdev()
+    test_eprtc_mtie()
+    test_prtcA_tdev()
+    test_prtcA_mtie()
+    test_prtcB_tdev()
+    test_prtcB_mtie()


### PR DESCRIPTION
Following https://github.com/aewallin/allantools/pull/116#issuecomment-587145150

Ubuntu 20.04 will indeed provide python 3 as default : https://lists.ubuntu.com/archives/ubuntu-devel/2020-February/040918.html.

So I think is is safe to drop python2.7 testing (and support). 

I suggest that the CI tests include the oldest version of python that is still supported (currently : 3.5)  and the latest stable one (currently: 3.8). This is the corresponding .travis.yml file.