### PR TITLE
Fix wrong link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Noise generators for creating synthetic datasets are also included:
 * pink noise with f^-1 PSD
 * Brownian or random walk noise with f^-2 PSD 
 
-More details on available statistics and noise generators : `full list of available functions <functions.html>`_  
+More details on available statistics and noise generators : `full list of available functions <https://allantools.readthedocs.io/en/latest/functions.html>`_  
 
 see /tests for tests that compare allantools output to other 
 (e.g. Stable32) programs. More test data, benchmarks, ipython notebooks, 


### PR DESCRIPTION
Link in `REAMDE.rst` points to a non existing URL. Changed to absolute link to readthedocs.io.

As it took me a while to figure out the correct link here as PR.

**Notes:** 
- On https://pypi.org/project/AllanTools/ it should also be fixed
- Should also work for the copied version `readme_copy.html` at readthedocs (in case you again copy a newer version at a later point)