### PR TITLE
avoiding numerical issues in tau generation

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -1706,11 +1706,12 @@ def tau_generator(data, rate, taus=None, v=False, even=False, maximum_m=-1):
     # mtotdev   2
     # ttotdev   2
 
-    taus_valid1 = taus < (1 / float(rate)) * float(len(data))
-    taus_valid2 = taus > 0
-    taus_valid3 = taus <= (1 / float(rate)) * float(maximum_m)
+    m = np.round(taus * rate)
+    taus_valid1 = m < len(data)
+    taus_valid2 = m > 0
+    taus_valid3 = m <= maximum_m
     taus_valid = taus_valid1 & taus_valid2 & taus_valid3
-    m = np.floor(taus[taus_valid] * rate)
+    m = m[taus_valid]
     m = m[m != 0]       # m is tau in units of datapoints
     m = np.unique(m)    # remove duplicates and sort
 


### PR DESCRIPTION
In taus='all' case 'taus' are calculated from integer window sizes, and calculating back the window sizes and using 'floor' can produce duplication which is filterred later out.

To avoid it, 'floor' is replaced with 'round'.

The original tau validation was not compatible with using 'floor', which can cause rounding up leading to larger than maximum window size. To solve it, windows size is calculated first and used for validation.