### PR TITLE
fix citations that were not links

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -598,8 +598,8 @@ def gcodev(data_1, data_2, rate=1.0, data_type="phase", taus=None):
 
     References
     ----------
-    * [Vernotte2016]
-    * [Lantz2019]
+    * [Vernotte2016]_
+    * [Lantz2019]_
     """
     phase_1 = input_to_phase(data_1, rate, data_type)
     phase_2 = input_to_phase(data_2, rate, data_type)

--- a/allantools/ci.py
+++ b/allantools/ci.py
@@ -789,7 +789,7 @@ def edf_simple(N, m, alpha):
 
     Notes
     -----
-       See [Stein1985]
+       See [Stein1985]_
 
     Returns
     -------

--- a/allantools/noise_kasdin.py
+++ b/allantools/noise_kasdin.py
@@ -258,7 +258,7 @@ class Noise(object):
 
         Coefficients from [Dawkins2007]_.
 
-        Vernotte2015 Table I
+        [Vernotte2015]_ Table I
 
         """
         # g_b = self.phase_psd_from_qd(tau0)


### PR DESCRIPTION
I did not change places where function arguments referenced a citation but the link was already in the main body of the description (i.e. `allantools.tdev_realtime`)