### PR TITLE
Fix usage of deprecated scipy.integrate function

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -111,7 +111,7 @@ import os
 import json
 import numpy as np
 from scipy import interpolate      # used in psd2allan()
-from scipy.integrate import simps  # used in psd2allan()
+from scipy.integrate import simpson  # used in psd2allan()
 
 from . import ci  # edf, confidence intervals
 
@@ -1756,7 +1756,7 @@ def psd2allan(S_y, f=1.0, kind='adev', base=2):
         for idx, mj in enumerate(m)])
     integrand = np.insert(integrand, 0, 0.0, axis=1)
     f = np.insert(f, 0, 0.0)
-    ad = np.sqrt(2.0 * simps(integrand, f))
+    ad = np.sqrt(2.0 * simpson(integrand, f))
     return taus_used, ad
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "AllanTools"
 version = "2024.04"
 dependencies = [
   "numpy",
-  "scipy",
+  "scipy>=1.6.0",
   "numpydoc",
   "matplotlib",
   "pytest",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy>=1.6.0
 numpydoc
 matplotlib
 pytest


### PR DESCRIPTION
switch from `scipy.integrate.simps` to `scipy.integrate.simpson`

scipy.integrate.simps was deprecated in scipy 1.12.0 and will be removed in 1.14 (the upcoming minor version number).

https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html#deprecated-features

This does introduce a requirement of scipy>=1.6.0, which is when scipy.integrate.simpson was introduced

https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html#scipy-integrate-improvements

We could use a conditional import if we want compatability with older versions?