### PR TITLE
remove usage of deprecated np.bool8 in tau_reduction

### DIFF
--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -1946,7 +1946,7 @@ def tau_reduction(ms, rate, n_per_decade):
 
     """
     ms = np.int64(ms)
-    keep = np.bool8(np.rint(n_per_decade*np.log10(ms[1:])) -
+    keep = np.bool_(np.rint(n_per_decade*np.log10(ms[1:])) -
                     np.rint(n_per_decade*np.log10(ms[:-1])))
     # Adjust ms size to fit above-defined mask
     ms = ms[:-1]


### PR DESCRIPTION
np.bool8 is an alias for np.bool_

np.bool8 was deprecated in numpy 1.24.0

https://numpy.org/doc/stable/release/1.24.0-notes.html#np-str0-and-similar-are-now-deprecated