### PR TITLE
Feature/adev2psd piecewise

### DIFF
--- a/allantools/.gitignore
+++ b/allantools/.gitignore
@@ -1,0 +1,8 @@
+# Jupyter / IPython
+.ipynb_checkpoints/
+**/.ipynb_checkpoints/
+.virtual_documents/
+
+# Python
+__pycache__/
+*.pyc

--- a/allantools/__init__.py
+++ b/allantools/__init__.py
@@ -72,6 +72,8 @@ from .allantools import trim_data
 from .allantools import psd2allan
 from .allantools import tau_generator
 from .allantools import tau_reduction
+from .allantools import adev2psd_piecewise_approx
+from .allantools import psd_piecewise_to_adev
 
 # ci.py contains functions for confidence intervals
 from .ci import edf_simple
@@ -84,6 +86,8 @@ from .ci import confidence_interval_noiseID
 
 # noise generation
 from . import noise
+
+from noise import timmer_koenig_from_psd
 
 from .dataset import Dataset
 from .plot import Plot

--- a/allantools/allantools.py
+++ b/allantools/allantools.py
@@ -1763,6 +1763,217 @@ def psd2allan(S_y, f=1.0, kind='adev', base=2):
     return taus_used, ad
 
 
+def adev2psd_piecewise_approx(adev, taus, vartype="adev", mu_tol=1e-5):
+    """
+    Approximate inverse mapping from deviation (ADEV/HDEV) to a piecewise
+    power-law one-sided fractional-frequency PSD Sy(f). This algorithm replaces
+    an ill-posed inverse problem (ADEV → PSD) with a well-posed constrained reconstruction,
+    by assuming local power-law behavior, enforcing continuity, and using the exact Allan 
+    integral to map time-domain slopes into frequency-domain energy.
+
+    Between consecutive tau nodes, the deviation is approximated as a power law.
+    Define the local slope
+
+        mu_i = 2 * (log(adev_{i+1}) - log(adev_i)) / (log(tau_{i+1}) - log(tau_i))
+
+    which corresponds to sigma_y^2(tau) ∝ tau^{mu_i}.
+
+    Each mu_i maps to a PSD exponent
+
+        alpha_i = -mu_i - 1
+
+    and the PSD is modeled as piecewise
+
+        Sy(f) = h_i * f^{alpha_i}
+
+    The coefficients h_i are obtained from the exact Allan/Hadamard integral
+    (De Marchi et al. 2024) through
+
+        J(mu) = ∫_0^∞ q(z) * sin^4(z) / z^{3+mu} dz
+
+    with q(z)=1 (ADEV) and q(z)=(4/3)sin^2(z) (HDEV).
+
+    Convergence conditions:
+        ADEV: -2 <= mu <= 2
+        HDEV: -2 <= mu <= 4
+
+    Parameters
+    ----------
+    adev : array_like
+        Deviation values (ADEV or HDEV), same length as `taus`.
+    taus : array_like
+        Averaging times tau in seconds (strictly increasing).
+    vartype : {'adev', 'hdev'}, optional
+        Deviation type. Default is 'adev'.
+    mu_tol : float, optional
+        Threshold for merging consecutive log-log slopes mu. Default 1e-5.
+
+    Returns
+    -------
+    f_nodes : ndarray
+        Break frequencies (Hz), ascending. Length is nseg-1 in the general case.
+    Sy_nodes : ndarray
+        Sy(f) evaluated at f_nodes (for convenience/plotting).
+    h : ndarray
+        PSD coefficients for each interval, length nseg.
+    alpha : ndarray
+        PSD exponents for each interval, length nseg.
+
+    References
+    ----------
+    F. De Marchi, M. K. Plumaris, E. A. Burt, and L. Iess,
+    "An Algorithm to Estimate the Power Spectral Density From Allan Deviation,"
+    IEEE Trans. UFFC, vol. 71, no. 4, pp. 506–515, 2024.
+    """
+    adev = np.asarray(adev, dtype=float)
+    taus = np.asarray(taus, dtype=float)
+
+    if adev.ndim != 1 or taus.ndim != 1 or adev.size != taus.size:
+        raise ValueError("adev and taus must be 1D arrays of equal length.")
+    if adev.size < 2:
+        raise ValueError("Need at least two points.")
+    if np.any(adev <= 0) or np.any(taus <= 0):
+        raise ValueError("adev and taus must be positive.")
+    if not np.all(np.diff(taus) > 0):
+        raise ValueError("taus must be strictly increasing.")
+
+    vt = vartype.lower()
+    if vt not in ("adev", "hdev"):
+        raise ValueError("vartype must be 'adev' or 'hdev'.")
+
+    def q(z):
+        return 1.0 if vt == "adev" else (4.0 / 3.0) * (np.sin(z) ** 2)
+
+    # --- match your original filtering of mu segments ---
+    mus = []
+    filtered_adev = [float(adev[0])]
+    filtered_tau = [float(taus[0])]
+
+    for i in range(1, adev.size):
+        mu = 2.0 * (np.log(adev[i]) - np.log(adev[i - 1])) / (np.log(taus[i]) - np.log(taus[i - 1]))
+        if (not mus) or (abs(mu - mus[-1]) > mu_tol):
+            mus.append(mu)
+            filtered_adev.append(float(adev[i]))
+            filtered_tau.append(float(taus[i]))
+
+    mus = np.asarray(mus, dtype=float)
+    filtered_adev = np.asarray(filtered_adev, dtype=float)
+    filtered_tau = np.asarray(filtered_tau, dtype=float)
+
+    # Convergence checks (exactly like your original)
+    for i, mu in enumerate(mus):
+        if vt == "adev" and not (-2.0 <= mu <= 2.0):
+            raise ValueError(
+                "Input ADEV cannot be converted to PSD: integral not convergent "
+                f"between nodes {filtered_tau[i]} [s] and {filtered_tau[i+1]} [s]."
+            )
+        if vt == "hdev" and not (-2.0 <= mu <= 4.0):
+            raise ValueError(
+                "Input HDEV cannot be converted to PSD: integral not convergent "
+                f"between nodes {filtered_tau[i]} [s] and {filtered_tau[i+1]} [s]."
+            )
+
+    # Bi coefficients (same indexing as your original)
+    Bi = np.array(
+        [filtered_adev[i] ** 2 * filtered_tau[i] ** (-mus[i - 1]) for i in range(1, mus.size + 1)],
+        dtype=float,
+    )
+
+    # hi coefficients (time-order), plus integral_values
+    hi = []
+    integral_values = []
+    for i in range(Bi.size):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=IntegrationWarning)
+            I, _ = quad(lambda z: q(z) * (np.sin(z) ** 4) / (z ** (3.0 + mus[i])), 0.0, np.inf)
+        integral_values.append(I)
+        hi.append(Bi[i] / (2.0 * I * (np.pi ** mus[i])))
+
+    integral_values = np.asarray(integral_values, dtype=float)
+    hi = np.asarray(hi, dtype=float)
+
+    # reverse hi for frequency ordering (exactly like your original)
+    hi = hi[::-1].copy()
+
+    # alphas derived from reversed mus (exactly like your original)
+    alphas = np.array([-mus[-(i + 1)] - 1.0 for i in range(mus.size)], dtype=float)
+
+    # frequency nodes and Sy(f_nodes) values (exactly like your original)
+    if filtered_adev.size == 2:
+        f_nodes = np.array([1.0 / t for t in filtered_tau], dtype=float)[::-1]
+        Sy_nodes = np.array([hi[0] * (f_nodes[i] ** alphas[0]) for i in range(f_nodes.size)], dtype=float)
+    else:
+        f_nodes = np.array(
+            [
+                1.0 / (10.0 * np.pi * filtered_tau[i]) *
+                (integral_values[i] / integral_values[i + 1]) ** (1.0 / (mus[i + 1] - mus[i]))
+                for i in range(mus.size - 1)
+            ],
+            dtype=float,
+        )[::-1]
+        Sy_nodes = np.array([hi[i] * (f_nodes[i] ** alphas[i]) for i in range(f_nodes.size)], dtype=float)
+
+    return f_nodes, Sy_nodes, hi, alphas
+
+def psd_piecewise_to_adev(h, alpha, f_nodes, taus):
+    """
+    Compute Allan deviation from a piecewise power-law one-sided PSD Sy(f).
+    Allan variance is related to Sy(f) by (NIST SP 1065):
+
+        sigma_y^2(tau) = 2 * ∫_0^∞ Sy(f) * sin^4(pi f tau) / (pi f tau)^2 df
+
+    For piecewise Sy(f)=h_i f^{alpha_i}, split the integral over
+    [0,f1), [f1,f2), ..., [f_last, +inf) and use z = pi*tau*f:
+
+        sigma_y^2(tau) = 2 * Σ_i h_i / (pi*tau)^{alpha_i+1}
+                         * ∫_{pi*tau*f_{i-1}}^{pi*tau*f_i}
+                           sin^4(z) / z^{2-alpha_i} dz
+
+    Parameters
+    ----------
+    h : array_like
+        PSD coefficients for each frequency interval, length nseg.
+    alpha : array_like
+        PSD exponents for each frequency interval, length nseg.
+    f_nodes : array_like
+        Frequency break nodes (Hz), ascending. Length nseg-1.
+    taus : array_like
+        Averaging times tau (seconds) at which to compute ADEV.
+
+
+    Returns
+    -------
+    adev : ndarray
+        Allan deviation values at each tau (same shape as taus).
+
+    References
+    ----------
+    NIST SP 1065, "Handbook of Frequency Stability Analysis", Eq. (65).
+    """
+    from scipy.integrate import quad, IntegrationWarning
+    h = np.asarray(h, dtype=float)
+    alpha = np.asarray(alpha, dtype=float)
+    f_nodes = np.asarray(f_nodes, dtype=float)
+    taus = np.asarray(taus, dtype=float)
+
+    def integrand(z, a):
+        return (np.sin(z) ** 4) / (z ** (2.0 - a))
+
+    edges = np.concatenate(([0.0], f_nodes, [np.inf]))
+    adev = np.empty_like(taus, dtype=float)
+
+    for k, tau in enumerate(taus):
+        sigma_y2 = 0.0
+        for i in range(h.size):
+            factor = h[i] / ((np.pi * tau) ** (alpha[i] + 1.0))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=IntegrationWarning)
+                I, _ = quad(integrand, np.pi * tau * edges[i], np.pi * tau * edges[i + 1], args=(alpha[i],))
+            sigma_y2 += factor * I
+        adev[k] = np.sqrt(2.0 * sigma_y2)
+
+    return adev
+    
 ########################################################################
 #
 #  Various helper functions and utilities

--- a/allantools/noise.py
+++ b/allantools/noise.py
@@ -206,3 +206,125 @@ def iterpink(depth=20):
         # replace value c with a new source element
         sumvals += source[i] - values[c]
         values[c] = source[i]
+
+from numpy.fft import ifft
+
+def timmer_koenig_from_psd(f_nodes, h, alpha, duration, timestep, output='phase', seed=None):
+    """
+    Generate time-domain clock noise from a piecewise power-law one-sided PSD Sy(f)
+    using a Timmer–Koenig-style Fourier synthesis.
+
+     Frequency grid (old convention used in your validated script):
+        n  = int(duration/dt)
+        f1 = 1 / ((n - 1) * dt)
+        fn = 1 / (2 * dt)
+        f_k = linspace(f1, fn, n/2 + 1)
+
+    Sample one-sided fractional-frequency PSD:
+        Sy(f) = h_i f^{alpha_i}
+
+    Convert to phase/time PSD:
+        Sx(f) = Sy(f) / (2*pi*f)^2
+
+    Generate complex spectrum coefficients (Timmer–Koenig style):
+        X_k = sqrt(Sx(f_k))/2 * (N(0,1) + i N(0,1))
+
+    Impose Hermitian symmetry and inverse FFT:
+        x = ifft(X) * sqrt((n-1)/dt)
+
+    Parameters
+    ----------
+    f_nodes : array_like
+        Break frequencies (Hz) defining PSD intervals, ascending.
+        Length is typically nseg-1.
+    h : array_like
+        PSD coefficients for each interval, length nseg.
+        Defines Sy(f) = h_i * f**alpha_i in each interval.
+    alpha : array_like
+        PSD slopes for each interval, length nseg.
+    duration : float
+        Total duration of generated time series (seconds).
+    timestep : float
+        Sampling interval dt (seconds). Sampling rate is fs = 1/dt.
+    output : {'phase', 'freq'}, optional
+        'phase' returns phase/time fluctuation x(t) [s].
+        'freq' returns fractional frequency y(t) = dx/dt [-].
+    seed : int or None, optional
+        Random seed for reproducible synthesis.
+
+    Returns
+    -------
+    x_or_y : ndarray
+        Time series of length n. If output='phase', returns x(t) [s].
+        If output='freq', returns y(t) [-].
+
+    References
+    ----------
+    J. Timmer and M. Koenig, "On generating power law noise",
+    Astronomy and Astrophysics, vol. 300, pp. 707–710, 1995.
+    """
+    f_nodes = np.asarray(f_nodes, dtype=float)
+    h = np.asarray(h, dtype=float)
+    alpha = np.asarray(alpha, dtype=float)
+
+    if duration <= 0 or timestep <= 0:
+        raise ValueError("duration and timestep must be positive.")
+    if h.size != alpha.size:
+        raise ValueError("h and alpha must have the same length.")
+    if f_nodes.size not in (0, h.size - 1):
+        # Typical output of your reconstruction: len(f_nodes)=len(h)-1
+        raise ValueError("Expected len(f_nodes) == len(h)-1 (or 0 for single segment).")
+
+    # Seed behavior: match numpy global RNG behavior used in your original code
+    if seed is not None:
+        np.random.seed(int(seed))
+
+    # Extrapolate behavior beyond the last node (matches your original)
+    h_ext = np.concatenate([h, [h[-1]]])
+    alpha_ext = np.concatenate([alpha, [alpha[-1]]])
+
+    n = int(duration / timestep)
+    if n < 4:
+        raise ValueError("duration/timestep too small; need at least 4 samples.")
+
+    f1 = 1.0 / ((n - 1) * timestep)
+    fn = 1.0 / (2.0 * timestep)
+    frequencies = np.linspace(f1, fn, n // 2 + 1)
+
+    # Sample Sy on this grid using the same interval logic as your original
+    Sy = np.zeros_like(frequencies)
+    for i, f in enumerate(frequencies):
+        if f_nodes.size > 0 and f < f_nodes[0]:
+            Sy[i] = h_ext[0] * f ** alpha_ext[0]
+        elif f_nodes.size > 0 and f > f_nodes[-1]:
+            Sy[i] = h_ext[-1] * f ** alpha_ext[-1]
+        else:
+            if f_nodes.size == 0:
+                Sy[i] = h_ext[0] * f ** alpha_ext[0]
+            else:
+                for j in range(1, f_nodes.size):
+                    if f_nodes[j - 1] <= f < f_nodes[j]:
+                        Sy[i] = h_ext[j] * f ** alpha_ext[j]
+                        break
+
+    # Convert Sy -> Sx
+    Sx = Sy / (2.0 * np.pi * frequencies) ** 2
+    Sx[0] = 0.0
+
+    # Build full complex spectrum and enforce Hermitian symmetry
+    X = np.zeros(n, dtype=complex)
+    for j in range(1, n // 2 + 1):
+        X[j] = (np.sqrt(Sx[j]) / 2.0) * (np.random.normal(0, 1) + 1j * np.random.normal(0, 1))
+
+    X[n // 2 + 1:] = np.conj(X[1:n // 2][::-1])
+
+    x = ifft(X) * np.sqrt((n - 1) / timestep)
+    x = x.real
+
+    if output == 'phase':
+        return x
+    elif output == 'freq':
+        return np.concatenate(([0.0], np.diff(x) / timestep))
+    else:
+        raise ValueError("output must be 'phase' or 'freq'.")
+        

--- a/examples/multi-color-noise-demo.py
+++ b/examples/multi-color-noise-demo.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# import numpy as np
+import matplotlib.pyplot as plt
+import allantools as at
+import math
+# note that latex requires e.g. a texlive installation and dvipng
+plt.rc('text', usetex=True)  # for latex
+plt.rc('font', family='serif')
+
+"""
+
+multi-colored noise example startinng from the ADEV
+
+This example uses the ADEV->PSD conversion () class and Kasdin&Walter
+updated 2018-01
+"""
+
+
+def main():
+
+    # Example Usage (Orolia RAFS)
+    taus =[10, 30, 120, 480, 1.92e3, 1.54e4, 6.14e4, 1.23e5, 2.46e5, 4.92e5, 9.83e5 ]
+    adevs = [1e-12, 3.99e-13, 1.66e-13, 8.85e-14, 4.15e-14, 1.62e-14, 8.99e-15, 9.73e-15, 1.17e-14, 1.26e-14, 1.36e-14]
+
+    # Example Usage (Accubeat USO)
+    #taus = [4, 8, 16, 32, 64, 128, 256, 512, 1.02e3, 2.05e3, 4.1e3, 8.19e3, 1.64e4, 3.28e4, 6.55e4]
+    #adevs = [1.07e-13, 1.04e-13, 9.84e-14, 1.04e-13, 1.11e-13, 1.21e-13, 1.33e-13, 1.49e-13, 1.6e-13, 2.17e-13, 3.4e-13, 6.6e-13, 1.12e-12, 1.97e-12, 3.27e-12]
+    
+    # 1) ADEV -> PSD parameters
+    f_nodes, Sy_nodes, h, alpha = at.adev2psd_piecewise_approx(adevs, taus, vartype="adev")
+    
+    # 2) PSD -> ADEV
+    adev_from_psd = at.psd_piecewise_to_adev(h, alpha, f_nodes, taus)
+    
+    # 3) PSD -> noise 
+    duration = taus[-1] * 100
+    timestep = taus[0] / 2
+    noise = at.noise.timmer_koenig_from_psd(f_nodes, h, alpha, duration, timestep, output='phase', seed=1)
+    
+    # 4) noise -> ADEV
+    taus_noise, adev_noise, _, _ = at.adev(noise, rate=1/timestep, data_type='phase', taus=taus)
+    
+    # Plot
+    plt.figure(figsize=(10, 6))
+    plt.loglog(taus, adevs, label="Original ADEV")
+    plt.loglog(taus, adev_from_psd, label="ADEV -> PSD -> ADEV")
+    plt.loglog(taus_noise, adev_noise, label="ADEV -> PSD -> noise -> ADEV")
+    plt.grid(which="both")
+    plt.ylabel("ADEV [-]")
+    plt.xlabel(r"$\tau$ [s]") 
+    plt.legend()
+    plt.show()
+
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds functionality to enable end-to-end noise simulation starting from Allan deviation (ADEV).
It introduces an approximate, piecewise power-law reconstruction of a physically consistent PSD from ADEV or HDEV, together with a compatible colored-noise synthesis routine. The added functions allow users to go from measured deviation → PSD model → simulated time-domain noise, and to verify consistency by recomputing ADEV from the generated noise.